### PR TITLE
Send token as header

### DIFF
--- a/packages/slack/src/api/base/index.ts
+++ b/packages/slack/src/api/base/index.ts
@@ -6,8 +6,8 @@ import { camel, snake } from '../../helpers/case'
 const stringify = (object: object) =>
   mapValues(snake(object), v => isObject(v) ? JSON.stringify(v) : v)
 
-const URI = (ns: string, method: string, token: string) =>
-  `https://slack.com/api/${ns}.${method}?token=${token}`
+const URI = (ns: string, method: string) =>
+  `https://slack.com/api/${ns}.${method}`
 
 export abstract class APIModule {
   protected namespace: string
@@ -22,8 +22,8 @@ export abstract class APIModule {
   }
 
   protected async request(method: string, form: object = {}) {
-    const uri = URI(this.namespace, method, this.token)
-    const response = await request(uri, stringify(form))
+    const uri = URI(this.namespace, method)
+    const response = await request(uri, stringify(form), this.token)
     if (!response.ok) throw new APIError(response.error)
     return camel(response)
   }

--- a/packages/slack/src/api/oauth.ts
+++ b/packages/slack/src/api/oauth.ts
@@ -12,7 +12,7 @@ export class Oauth extends APIModule {
       code: options.code,
       redirect_uri: options.redirectUri
     }
-    const response = await request(uri, form)
+    const response = await request(uri, form, options.secret)
     if (!response.ok) throw new APIError(response.error)
     return camel(response)
   }


### PR DESCRIPTION
Reimplement of #32 without version changes and tarball

> Given that new Slack apps do not work with token sent as GET parameter we need to send it in header. This PRs adds that.