### PR TITLE
[CI] Add gha-creds to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ test/tmp
 coverage
 dist
 .nyc_output
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
### Description
Add gha-creds to `.gitignore` according to [gsm-secrets action README](https://github.com/toptal/actions/tree/main/gsm-secrets). This PR was created automatically.