### PR TITLE
Fix getting JSON response for 204 status code

### DIFF
--- a/packages/slack/src/request.ts
+++ b/packages/slack/src/request.ts
@@ -23,7 +23,7 @@ function sanitizeTimeout(timeout) {
 }
 
 function getJSON(response) {
-    if (response.status === 204) return '';
+    if (response.status === 204) return {};
     return response.json();
 }
 

--- a/packages/slack/src/request.ts
+++ b/packages/slack/src/request.ts
@@ -22,6 +22,11 @@ function sanitizeTimeout(timeout) {
     return undefined
 }
 
+function getJSON(response) {
+    if (response.status === 204) return '';
+    return response.json();
+}
+
 class BadStatusCodeError extends Error {
     statusCode: number
     response: any
@@ -68,7 +73,7 @@ async function request(method, { uri, headers, body, form, json, timeout }): Pro
         if (response.status >= 400) {
             throw new BadStatusCodeError(response)
         }
-        return json ? response.json() : response
+        return json ? getJSON(response) : response
     }
     catch (err) {
         if (err.name === 'AbortError') {


### PR DESCRIPTION
If a JSON request returns valid 204 status code the `request.json()` function fails with:

```
Unexpected end of JSON input
```

This is a known issue https://github.com/whatwg/fetch/issues/113 

One of the suggested solutions is to check the status code and just return empty ~string~ object, which seems a good option for that issue.